### PR TITLE
Bugfix: Remove Duplicate Maths Subject Entry in 1st Year CSE Data

### DIFF
--- a/src/components/Branches.jsx
+++ b/src/components/Branches.jsx
@@ -39,7 +39,7 @@ const Branches ={
                     "link": "https://link-to-maths-syllabus"
                   }
                 },
-
+                
                 {
                   "subjectName": "Chemistry",
                   "notesPage": "https://link-to-chemistry-notes",

--- a/src/components/Branches.jsx
+++ b/src/components/Branches.jsx
@@ -39,35 +39,7 @@ const Branches ={
                     "link": "https://link-to-maths-syllabus"
                   }
                 },
-{
-      "subjectName": "Maths",
-      "Note": [
-        {
-          "title": "Note 1",
-          "noteLink": "https://youtube.com"
-        },
-        {
-          "title": "Note 2",
-          "noteLink": "https://youtube.com"
-        },
-        {
-          "title": "Note 3",
-          "noteLink": "https://youtube.com"
-        }
-      ],
-      "youtubeLink": {
-        "title": "Maths Tutorial",
-        "link": "https://youtube.com/maths-tutorial"
-      },
-      "PYQ": {
-        "title": "Maths Previous Year Questions",
-        "link": "https://link-to-maths-pyq"
-      },
-      "syllabus": {
-        "title": "Maths Syllabus",
-        "link": "https://link-to-maths-syllabus"
-      }
-    },
+
                 {
                   "subjectName": "Chemistry",
                   "notesPage": "https://link-to-chemistry-notes",


### PR DESCRIPTION
## 1. Title
**Bugfix: Resolve duplicate Maths subject entries causing data inconsistency in 1st Year CSE**

## 2. Description
This pull request addresses a critical data structure issue in the Branches.jsx file where the "Maths" subject appears twice in the 1st Year CSE subjects array. The bugfix includes:
## 3. Related Issues
Fixes #12 

## 3. Testing Performed
- [x] Verified JSON structure validity after duplicate removal
- [x] Confirmed no breaking changes to existing functionality
- [x] Tested subject selection UI with cleaned data
- [x] Validated that all Maths resources remain accessible
- [x] Ensured consistent data structure across all years/branches

## 4. Screenshots

### Before (Bug State):
<img width="931" height="523" alt="Screenshot 2025-08-11 at 4 52 05 PM" src="https://github.com/user-attachments/assets/c6c816ed-ea3d-4042-90ae-35136511ac6e" />

### After (Bug Fixed):
<img width="1469" height="796" alt="Screenshot 2025-08-12 at 9 12 20 PM" src="https://github.com/user-attachments/assets/04d74cbe-0afd-4e37-8325-7f6e55a5cb09" />
**Ready for Review**: ✅ All changes tested and verified. Kindly review and merge this critical bugfix.

**Vercel Authorization Needed**: Please authorize Vercel deployment for this fix.
