### PR TITLE
Fix: navbar active page highlighting (#86)

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -48,8 +48,10 @@
   flex-shrink: 0;
 }
 
-.nav-link.text-danger {
+/* Active link styles */
+.nav-link.active {
   color: red;
+  font-weight: bold;
 }
 
 .nav-link.text-black {
@@ -142,7 +144,7 @@ select {
   color: white;
 }
 
-[data-theme="dark"] .nav-link.text-danger {
+[data-theme="dark"] .nav-link.active {
   color: #ff6f61; /* lighter red */
 }
 
@@ -170,7 +172,7 @@ select {
   color: black;
 }
 
-[data-theme="light"] .nav-link.text-danger {
+[data-theme="light"] .nav-link.active {
   color: red;
 }
 

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -35,22 +35,22 @@ const NavBar = () => {
 
   return (
     <div className={`navbar-container ${theme === "light" ? "bg-white" : "bg-dark"}`}>
-      <Link to="/"  className={`nav-link ${theme === "light" ? "text-danger" : "text-danger-light"}`}>
+      <Link to="/"  className="nav-link"> 
         <div className="navbar-logo">
           <img src={Logo} alt="Logo" className="logo-img" />
           <p className={`logo-text ${theme === "light" ? "text-black" : "text-light"}`}>
-            <span className="text-danger">Pustak</span> <span>Ghar</span>
+            <span style={{ color: theme === "light" ? "red" : "#ff6f61" }}>Pustak</span> <span>Ghar</span>
           </p>
         </div>
       </Link>
 
       <div className={`navbar-links ${menuOpen ? `show ${theme === "light" ? "bg-white" : "bg-dark"}` : ""}`}>
-        <Link to="/" className={`nav-link ${theme === "light" ? "text-danger" : "text-danger-light"}`}>HOME</Link>
-        <Link to="/resources" className={`nav-link ${theme === "light" ? "text-black" : "text-light"}`}>MORE</Link>
-        <Link to="/" className={`nav-link ${theme === "light" ? "text-black" : "text-light"}`}>JOIN</Link>
-        <Link to="/about" className={`nav-link ${theme === "light" ? "text-black" : "text-light"}`}>ABOUT</Link>
-        <Link to="/contribute" className={`nav-link ${theme === "light" ? "text-black" : "text-light"}`}>CONTRIBUTE</Link>
-        <Link to="/upload" className={`nav-link ${theme === "light" ? "text-black" : "text-light"}`}>UPLOAD</Link>
+        <Link to="/" className={`nav-link ${pathname === "/" ? "active" : ""}`}>HOME</Link>
+        <Link to="/resources" className={`nav-link ${pathname === "/resources" ? "active" : ""}`}>MORE</Link>
+        <Link to="/join" className={`nav-link ${pathname === "/join" ? "active" : ""}`}>JOIN</Link>
+        <Link to="/about" className={`nav-link ${pathname === "/about" ? "active" : ""}`}>ABOUT</Link>
+        <Link to="/contribute" className={`nav-link ${pathname === "/contribute" ? "active" : ""}`}>CONTRIBUTE</Link>
+        <Link to="/upload" className={`nav-link ${pathname === "/upload" ? "active" : ""}`}>UPLOAD</Link>
       </div>
 
       <div className="nav-controls" style={{ display: "flex", alignItems: "center" }}>


### PR DESCRIPTION
### Summary
This PR fixes the issue where the navbar always highlighted HOME in red regardless of the current page.

### Changes
- Updated `NavBar.jsx` to dynamically apply the `active` class based on `pathname`
- Updated `NavBar.css` to style the `active` link appropriately

### Fixes
Resolves #86

### Before
- HOME was always highlighted red.

### After
- Only the active page link is highlighted red in both themes light & dark mode. e.g. MORE when on /resources.
 
<img width="1885" height="525" alt="Screenshot 2025-08-31 023247" src="https://github.com/user-attachments/assets/9955fbde-40d7-4b29-bbd5-7a918559f59e" />

<img width="1884" height="536" alt="Screenshot 2025-08-31 023309" src="https://github.com/user-attachments/assets/c4de7727-ecff-47e0-9310-fe5b6319f4ba" />

