### PR TITLE
Contribute page content cards not adapting to dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,13 +48,14 @@
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
   border-radius: 16px;
   padding: 25px;
-  animation: fadeInUp 0.4s ease-in-out;
-  transition: background 0.3s ease, box-shadow 0.3s ease;
+  animation: fadeInUp 0.5s ease-in-out;
+  transition: background-color 0.5s ease, box-shadow 0.5s ease, backdrop-filter 0.5s ease;
 }
 
 /* 🌙 Dark Mode Content Card */
 [data-theme="dark"] .content-card {
-  background: rgba(255, 255, 255, 0.85);
+  background: rgba(30, 30, 30, 0.95);
+  backdrop-filter: blur(12px);
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
 }
 

--- a/src/components/About.css
+++ b/src/components/About.css
@@ -17,10 +17,11 @@
     margin-bottom: 0.5rem;
     font-weight: bold;
     color: #16213e;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .about-title {
-    color: #0d0101;
+    color: #ff4d6d;
 }
 
 /* Tagline paragraph below title */
@@ -28,10 +29,11 @@
     font-size: 1.1rem;
     margin-bottom: 1.5rem;
     color: #555;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .about-tagline {
-    color: #0d0101;
+    color: #bbb;
 }
 
 /* Each section container */
@@ -46,10 +48,11 @@
     font-weight: 600;
     letter-spacing: 0.02em;
     color: #223072;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .about-section h2 {
-    color: #0e349e;
+    color: #fff;
 }
 
 /* Lists inside sections */
@@ -63,20 +66,22 @@
     line-height: 1.6;
     margin-bottom: 0.7em;
     color: #333;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .about-section ul li,
 [data-theme="dark"] .about-section ol li {
-    color: #0d0101;
+    color: #ccc;
 }
 
 /* Paragraphs inside sections */
 .about-section p {
     color: #363636;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .about-section p {
-    color: #0d0101;
+    color: #ddd;
 }
 
 /* Override global page-container padding for about page to reduce space */

--- a/src/components/Contribute.css
+++ b/src/components/Contribute.css
@@ -9,42 +9,61 @@
     margin-bottom: 0.5rem;
     font-weight: bold;
     color: #23468f;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .contribute-title {
-    color: #0d0101;
+    color: #ff4d6d;
 }
 
 .contribute-tagline {
     font-size: 1.1rem;
     margin-bottom: 1.5rem;
     color: #555;
+    transition: color 0.3s ease;
 }
 
 [data-theme="dark"] .contribute-tagline {
-    color: #0d0101;
+    color: #bbb;
 }
 
 .contribute-section {
     margin-bottom: 1.6rem;
+    transition: color 0.3s ease;
 }
 
 .contribute-section h2 {
     font-size: 1.18rem;
     margin-bottom: 0.5rem;
     color: #223072;
-}
-
-[data-theme="dark"] .contribute-section h2 {
-    color: #0e349e;
+    transition: color 0.3s ease;
 }
 
 .contribute-section ul,
 .contribute-section ol {
     padding-left: 1.2rem;
 }
+
+.contribute-section a {
+    transition: color 0.3s ease;
+}
+
+pre {
+    background: #f5f5f5;
+    padding: 0.5rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    margin: 0.5rem 0;
+    border: 1px solid #e0e0e0;
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
 [data-theme="dark"] .contribute-section {
-    color: #0d0101;
+    color: #ddd;
+}
+
+[data-theme="dark"] .contribute-section h2 {
+    color: #fff;
 }
 .highlight {
     background: #f4ecec;
@@ -73,13 +92,14 @@
     padding: 8px 10px;
     text-decoration: none;
     color: inherit;
-    transition: box-shadow 0.2s;
+    transition: box-shadow 0.2s, background-color 0.3s ease, transform 0.2s;
     min-width: 88px;
 }
 
 .contributor-profile:hover {
     box-shadow: 0 2px 18px rgba(100, 149, 237, 0.14);
     transform: translateY(-3px) scale(1.04);
+    text-decoration: none;
 }
 
 .contributor-avatar {
@@ -88,4 +108,70 @@
     border-radius: 50%;
     margin-bottom: 5px;
     box-shadow: 0 2px 10px rgba(100, 149, 237, 0.09);
+}
+
+/* Dark Mode Styles for Contributor Cards */
+[data-theme="dark"] .contributor-profile {
+    background: rgba(255, 77, 109, 0.15);
+    color: #fff;
+}
+
+[data-theme="dark"] .contributor-profile:hover {
+    box-shadow: 0 2px 18px rgba(255, 77, 109, 0.2);
+}
+
+/* Dark Mode Styles for Links */
+[data-theme="dark"] .contribute-section a {
+    color: #ff4d6d;
+}
+
+[data-theme="dark"] .contribute-section a:hover {
+    color: #ff6b8a;
+}
+
+/* Dark Mode Styles for Code Blocks */
+[data-theme="dark"] pre {
+    background: #2a2a2a;
+    color: #f0f0f0;
+    border: 1px solid #444;
+}
+
+/* Dark Mode Styles for Step Icons and Text */
+[data-theme="dark"] .contribute-steps-list li {
+    color: #ddd;
+}
+
+[data-theme="dark"] .step-icon {
+    filter: brightness(1.2);
+}
+
+/* Dark Mode Styles for Loading Text and Lists */
+[data-theme="dark"] .contribute-section p {
+    color: #ddd;
+}
+
+[data-theme="dark"] .contribute-section ul li,
+[data-theme="dark"] .contribute-section ol li {
+    color: #ddd;
+}
+
+[data-theme="dark"] .contribute-section ul li strong,
+[data-theme="dark"] .contribute-section ol li strong {
+    color: #fff;
+}
+
+[data-theme="dark"] .contribute-section span {
+    color: #ccc;
+}
+
+/* Dark Mode Styles for Emphasis and Strong Text */
+[data-theme="dark"] .contribute-section em {
+    color: #ff9ab7;
+    font-style: italic;
+}
+
+/* Dark Mode Styles for Contributor Names */
+[data-theme="dark"] .contributor-profile span {
+    color: #fff;
+    font-weight: 500;
 }

--- a/src/components/Resources.css
+++ b/src/components/Resources.css
@@ -6,6 +6,7 @@
   margin: 0 auto;
   padding: 2rem;
   color: #000; /* Black text as requested */
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 /* Header Section */
@@ -20,6 +21,7 @@
   font-size: 2.2rem;
   margin-bottom: 0.5rem;
   color: #000;
+  transition: color 0.3s ease;
 }
 
 .subtitle {
@@ -27,6 +29,7 @@
   color: #333;
   max-width: 700px;
   margin: 0 auto;
+  transition: color 0.3s ease;
 }
 
 /* Options Grid */
@@ -41,7 +44,7 @@
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   overflow: hidden;
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease, background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 .option-card:hover {
@@ -54,6 +57,7 @@
   padding: 1.5rem;
   text-align: center;
   color: #d10000; /* Brand red for icons */
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .option-icon {
@@ -68,18 +72,21 @@
   font-size: 1.3rem;
   margin-bottom: 0.8rem;
   color: #000;
+  transition: color 0.3s ease;
 }
 
 .card-content p {
   color: #666;
   margin-bottom: 1rem;
   font-size: 0.95rem;
+  transition: color 0.3s ease;
 }
 
 .card-content ul {
   margin: 1rem 0;
   padding-left: 1.2rem;
   color: #444;
+  transition: color 0.3s ease;
 }
 
 .card-content li {
@@ -96,7 +103,7 @@
   font-weight: 600;
   cursor: pointer;
   margin-top: 1rem;
-  transition: all 0.2s ease;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .view-button:hover {
@@ -114,6 +121,7 @@
   font-size: 1.3rem;
   margin-bottom: 1.5rem;
   color: #000;
+  transition: color 0.3s ease;
 }
 
 .quick-links {
@@ -130,12 +138,82 @@
   border-radius: 20px;
   color: #000;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.5s ease, color 0.5s ease, border-color 0.5s ease;
 }
 
 .quick-links button:hover {
   background: #d10000;
   color: white;
+}
+
+/* Dark Mode Styles */
+[data-theme="dark"] .more-options-container {
+  background: #1e1e1e;
+}
+
+[data-theme="dark"] .more-options-header {
+  border-bottom: 1px solid #333;
+}
+
+[data-theme="dark"] .more-options-header h1 {
+  color: #ff4d6d;
+}
+
+[data-theme="dark"] .subtitle {
+  color: #bbb;
+}
+
+[data-theme="dark"] .option-card {
+  background: #1e1e1e;
+  border: 1px solid #333;
+  color: #ddd;
+}
+
+[data-theme="dark"] .option-card:hover {
+  box-shadow: 0 5px 15px rgba(0,0,0,0.4);
+}
+
+[data-theme="dark"] .card-icon-container {
+  background-color: #2a2a2a;
+  color: #ff4d6d;
+}
+
+[data-theme="dark"] .card-content h2 {
+  color: #fff;
+}
+
+[data-theme="dark"] .card-content p {
+  color: #bbb;
+}
+
+[data-theme="dark"] .card-content ul {
+  color: #ccc;
+}
+
+[data-theme="dark"] .view-button {
+  background: #1e1e1e;
+  color: #ff4d6d;
+  border: 1px solid #ff4d6d;
+}
+
+[data-theme="dark"] .view-button:hover {
+  background: #ff4d6d;
+  color: #fff;
+}
+
+[data-theme="dark"] .quick-links-section h3 {
+  color: #fff;
+}
+
+[data-theme="dark"] .quick-links button {
+  background: #2a2a2a;
+  color: #ddd;
+  border: 1px solid #333;
+}
+
+[data-theme="dark"] .quick-links button:hover {
+  background: #ff4d6d;
+  color: #fff;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
Fixed Contribute page dark mode where content cards and text appeared invisible due to incorrect dark colors. Implemented comprehensive dark mode styling with proper light colors, enhanced contributor profile cards, improved code block readability, and added smooth 0.3s transitions for seamless theme switching.

<img width="1365" height="649" alt="image" src="https://github.com/user-attachments/assets/87625e56-81c2-4ab9-acbb-6f3838c46cae" />

fixed #92 