### PR TITLE
Moved the light/dark toggle button into the hamburger menu in the mobile view

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -180,6 +180,17 @@ select {
   color: black;
 }
 
+/* Hide desktop toggle on mobile */
+.desktop-theme-toggle {
+  display: flex;
+  align-items: center;
+}
+
+.mobile-theme-toggle {
+  display: none;
+  margin-top: 10px; /* spacing inside menu */
+}
+
 /* -------- Mobile Responsive -------- */
 @media (max-width: 768px) {
   .navbar-links {
@@ -206,4 +217,20 @@ select {
   }
 
   .hamburger { display: block; }
+
+  .desktop-theme-toggle {
+    display: none; /* hide desktop toggle */
+  }
+
+  .mobile-theme-toggle {
+    display: flex; /* show inside hamburger menu */
+    justify-content: flex-start;
+  }
+  
+  .theme-toggle-btn {
+    width: 100%;
+    text-align: left;
+    padding: 0.5rem 0.7rem;
+    border-radius: 6px;
+  }
 }

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -51,10 +51,23 @@ const NavBar = () => {
         <Link to="/about" className={`nav-link ${pathname === "/about" ? "active" : ""}`}>ABOUT</Link>
         <Link to="/contribute" className={`nav-link ${pathname === "/contribute" ? "active" : ""}`}>CONTRIBUTE</Link>
         <Link to="/upload" className={`nav-link ${pathname === "/upload" ? "active" : ""}`}>UPLOAD</Link>
+
+        {/* Dark/Light toggle for mobile */}
+        <div className="mobile-theme-toggle">
+          <button
+          onClick={toggleTheme}
+          aria-label="Toggle light/dark theme"
+          className={`theme-toggle-btn ${theme}`}
+          >
+            {theme === "light" ? "🌙 Dark" : "🌞 Light"}
+          </button>
+        </div>
       </div>
 
       <div className="nav-controls" style={{ display: "flex", alignItems: "center" }}>
-        <button
+        {/* Desktop toggle only */}
+        <div className="desktop-theme-toggle">
+         <button
           onClick={toggleTheme}
           aria-label="Toggle light/dark theme"
           className={`theme-toggle-btn ${theme}`}
@@ -70,7 +83,8 @@ const NavBar = () => {
           }}
         >
           {theme === "light" ? "🌙 Dark": "🌞 Light"}
-        </button>
+         </button>
+        </div>
 
         <button
           ref={menuButtonRef}


### PR DESCRIPTION
- Added a desktop theme toggle beside the hamburger menu.
- Moved mobile theme toggle inside the hamburger menu for small screens.
- Updated CSS to hide/show toggles appropriately and prevent overlap.
- Theme switching updates data-theme dynamically for light/dark mode.

BEFORE:

<img width="1207" height="720" alt="Screenshot 2025-09-06 190340" src="https://github.com/user-attachments/assets/daee3405-b1fd-48eb-abdb-af502e647b51" />

AFTER: 

<img width="1203" height="975" alt="Screenshot 2025-09-09 191325" src="https://github.com/user-attachments/assets/8af6bc48-117e-4051-bf85-4a17e5d4b02f" />

